### PR TITLE
Fix Typewriter animation cleanup

### DIFF
--- a/components/AnimationComponents.tsx
+++ b/components/AnimationComponents.tsx
@@ -220,9 +220,10 @@ export function Typewriter({
   useEffect(() => {
     if (isInView && !isTyping) {
       setIsTyping(true);
+      let typingInterval: ReturnType<typeof setInterval>;
       const timer = setTimeout(() => {
         let i = 0;
-        const typingInterval = setInterval(() => {
+        typingInterval = setInterval(() => {
           if (i < text.length) {
             setDisplayText(text.slice(0, i + 1));
             i++;
@@ -230,11 +231,14 @@ export function Typewriter({
             clearInterval(typingInterval);
           }
         }, speed);
-
-        return () => clearInterval(typingInterval);
       }, delay);
 
-      return () => clearTimeout(timer);
+      return () => {
+        clearTimeout(timer);
+        if (typingInterval) {
+          clearInterval(typingInterval);
+        }
+      };
     }
   }, [isInView, text, delay, speed, isTyping]);
 


### PR DESCRIPTION
## Summary
- ensure Typewriter animation cleans up timers

## Testing
- `npm run lint` (fails: unescaped apostrophes in multiple page files)
- `npm run build` (fails: failed to fetch Google Fonts)


------
https://chatgpt.com/codex/tasks/task_e_68a0541df5008332bb8cfaf65c71957e