### PR TITLE
Clarify RouteTransition comment about navigation exits

### DIFF
--- a/components/RouteTransition.tsx
+++ b/components/RouteTransition.tsx
@@ -3,8 +3,8 @@
 import { useEffect, useRef } from "react";
 import { usePathname, useRouter } from "next/navigation";
 
-// A lightweight route transition wrapper that applies exit animation
-// before navigating to new route via Nav links that call push().
+// Applies exit animation before navigating to a new route when links
+// inside the navigation are clicked.
 export default function RouteTransition({
   children,
 }: {


### PR DESCRIPTION
## Summary
- clarify comment describing RouteTransition's exit animation when nav links are clicked

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: unescaped entities in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68a05662905c83329a33782cd42583f3