### PR TITLE
Translate animation component comments to English

### DIFF
--- a/components/AnimationComponents.tsx
+++ b/components/AnimationComponents.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useRef, useState } from "react";
 
-// Hook untuk intersection observer
+// Hook for intersection observer
 export function useInView(threshold = 0.1) {
   const [isInView, setIsInView] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
@@ -29,7 +29,7 @@ export function useInView(threshold = 0.1) {
   return [ref, isInView] as const;
 }
 
-// Komponen untuk fade in animation
+// Component for fade-in animation
 interface FadeInProps {
   children: React.ReactNode;
   delay?: number;
@@ -75,7 +75,7 @@ export function FadeIn({
   );
 }
 
-// Komponen untuk staggered animation
+// Component for staggered animation
 interface StaggeredFadeInProps {
   children: React.ReactNode[];
   staggerDelay?: number;
@@ -105,7 +105,7 @@ export function StaggeredFadeIn({
   );
 }
 
-// Komponen untuk scale animation
+// Component for scale animation
 interface ScaleInProps {
   children: React.ReactNode;
   delay?: number;
@@ -130,7 +130,7 @@ export function ScaleIn({ children, delay = 0, className = "" }: ScaleInProps) {
   );
 }
 
-// Komponen untuk slide animation
+// Component for slide animation
 interface SlideInProps {
   children: React.ReactNode;
   direction: "left" | "right";
@@ -165,7 +165,7 @@ export function SlideIn({
   );
 }
 
-// Komponen untuk parallax effect
+// Component for parallax effect
 interface ParallaxProps {
   children: React.ReactNode;
   offset?: number;
@@ -199,7 +199,7 @@ export function Parallax({
   );
 }
 
-// Komponen untuk typing animation
+// Component for typing animation
 interface TypewriterProps {
   text: string;
   delay?: number;
@@ -246,7 +246,7 @@ export function Typewriter({
   );
 }
 
-// Komponen untuk gradient text animation
+// Component for gradient text animation
 interface AnimatedGradientTextProps {
   children: React.ReactNode;
   className?: string;


### PR DESCRIPTION
## Summary
- Replace Indonesian comments with English equivalents for the intersection observer hook
- Translate animation component comments (fade, staggered, scale, slide, parallax, typing, gradient text) to English for consistency

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: react/no-unescaped-entities and react-hooks warnings in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_68a0564bf7e4833280db04603ced95c1